### PR TITLE
Fix AdmissionReview uid quoted string

### DIFF
--- a/src/admission_review.rs
+++ b/src/admission_review.rs
@@ -19,7 +19,7 @@ impl AdmissionReview {
 
         let request = serde_json::to_string(req)?;
         let uid = match req.get("uid") {
-            Some(uid) => uid.to_string(),
+            Some(uid) => uid.as_str().unwrap().to_string(),
             None => return Err(anyhow!("Cannot parse AdmissionReview: 'uid' not found")),
         };
 


### PR DESCRIPTION
Without this change, the JSON-encoded AdmissionReview response object
contains a uid string with escaped double quotes. When used as a webhook
in Kubernetes, the API server will reject a valid pod creation request
with a log message like this:

  failed calling webhook "rule-0.chimera.admission.rule": expected response.uid="44286a79-e64e-45f8-b66a-7ef4342e856f", got "\"44286a79-e64e-45f8-b66a-7ef4342e856f\""

This is because the uid is a serde_json::Value object[1]. It needs to be
converted to a &str with as_str and then to a String with to_string() in
order to avoid the extra quotes.

[1] https://docs.serde.rs/serde_json/#operating-on-untyped-json-values