### PR TITLE
Add error handling to main()

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -31,7 +31,7 @@ pub(crate) struct PolicyEvaluator {
 }
 
 impl PolicyEvaluator {
-    pub(crate) fn new(wasm_file: String) -> Result<PolicyEvaluator, anyhow::Error> {
+    pub(crate) fn new(wasm_file: &String) -> Result<PolicyEvaluator, anyhow::Error> {
         let mut f = File::open(wasm_file)?;
         let mut buf = Vec::new();
         f.read_to_end(&mut buf)?;


### PR DESCRIPTION
Where user input could cause an error, replace calls to unwrap() with
error messages and an exit code rather than panicking.

Fixes #2 