### PR TITLE
Allow user to define multiple policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1702,7 @@ dependencies = [
  "openssl",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio 1.1.0",
  "tokio-compat-02",
  "tokio-native-tls",
@@ -2095,6 +2108,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -3115,6 +3140,15 @@ dependencies = [
  "hyperx",
  "unicase 1.4.2",
  "url 1.7.2",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ native-tls = "^0.2.1"
 num_cpus = "1.13.0"
 oci-distribution = "0.4"
 openssl = "0.10.32"
+serde_yaml = "0.8.15"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio-compat-02 = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,99 @@
-Experimental rewrite in rust of the chimera admission controller.
+> **Note well:** don't forget to checkout [Chimera's documentation](https://chimera-kube.github.io/chimera-book/)
+> for more information
 
-Leverages waPC instead of WASI to write policies.
+# policy-server
+
+`policy-server` is a
+[Kubernetes dynamic admission controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
+that uses Chimera Policies to validate admission requests.
+
+Chimera Policies are simple [WebAssembly](https://webassembly.org/)
+modules.
+
+# Deployment
+
+We recommend to rely on the [chimera-controller](https://github.com/chimera-kube/chimera-controller)
+and the [Kubernetes Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+provided by it to deploy the Chimera stack.
+
+## Configuring policies
+
+A single instance of `policy-server` can load multiple Chimera policies. The list
+of policies to load, how to expose them and their runtime settings are handled
+through a policies file.
+
+By default `policy-server` will load the `policies.yml` file, unless the user
+provides a different value via the `--policies` flag.
+
+This is an example of the policies file:
+
+```yml
+dedicated_nodes_tenant_A:
+  url: registry://ghcr.io/chimera-kube/policies/pod-toleration:v0.0.2
+  settings:
+    taint_key: dedicated
+    taint_value: tenantA
+    allowed_groups:
+      - administrators
+      - tenant-a-users
+dedicated_nodes_tenant_B:
+  url: registry://ghcr.io/chimera-kube/policies/pod-toleration:v0.0.2
+  settings:
+    taint_key: dedicated
+    taint_value: tenantB
+    allowed_groups:
+      - administrators
+      - tenant-b-users
+namespace_simple:
+  url: file:///tmp/namespace-validate-policy.wasm
+  settings:
+    valid_namespace: chimera-approved
+```
+
+The YAML file contains a dictionary with strings as keys, and policy objects as values.
+
+The key that identifies a policy is used by `policy-server` to expose the policy
+through its web interface. Policies are exposed under `/validate/<policy id>.
+
+For example, given the configuration file from above, the following API endpoint
+would be created:
+
+  * `/validate/dedicated_nodes_tenant_A`: this exposes the `pod-toleration:v0.0.2`
+    policy. The Wasm module is downloaded from the OCI registry of GitHub.
+  * `/validate/dedicated_nodes_tenant_B`: this exposes the `pod-toleration:v0.0.2`
+    policy. The Wasm module is downloaded from the OCI registry of GitHub.
+  * `/validate/namespace_simple`: this exposes the `namespace-validate-policy`
+    policy. The Wasm module is loaded from a local file located under `/tmp/namespace-validate-policy.wasm`.
+
+It's common for policies to allow users to tune their behaviour via ad-hoc settings.
+These customization parameters are provided via the `settings` dictionary.
+
+For example, given the configuration file from above, the `namespace_simple` policy
+will be invoked with the `valid_namespace` parameter set to `chimera-approved`.
+
+Note well: it's possible to expose the same policy multiple times, each time with
+a different set of paraments. For example, given the configuration file from above,
+this is done by the `dedicated_nodes_tenant_A` and by the `dedicated_nodes_tenant_B` endpoints.
+
+The Wasm file providing the Chimera Policy can be either loaded from
+the local filesystem or it can be fetched from a remote location. The behaviour
+depends on the URL format provided by the user:
+
+* `file:///some/local/program.wasm`: load the policy from the local filesystem
+* `https://some-host.com/some/remote/program.wasm`: download the policy from the
+  remote http(s) server
+* `registry://localhost:5000/project/artifact:some-version` download the policy
+  from a OCI registry. The policy must have been pushed as an OCI artifact
+
+
+## Building
+
+You can either build `chimera-admission` from sources (see below) or you can
+use the container image we maintain inside of our
+[GitHub Container Registry](https://github.com/orgs/chimera-kube/packages/container/package/policy-server).
+
+The `policy-server` binary can be built in this way:
+
+```shell
+$ cargo build
+```

--- a/policies.yml.example
+++ b/policies.yml.example
@@ -1,0 +1,17 @@
+dedicated_nodes_tenant_A:
+  url: registry://ghcr.io/chimera-kube/policies/pod-toleration:v0.0.2
+  settings:
+    taint_key: dedicated
+    taint_value: tenantA
+    allowed_groups:
+      - administrators
+      - tenant-a-users
+dedicated_nodes_tenant_B:
+  url: registry://ghcr.io/chimera-kube/policies/pod-toleration:v0.0.2
+  settings:
+    taint_key: dedicated
+    taint_value: tenantB
+    allowed_groups:
+      - administrators
+      - tenant-b-users
+

--- a/src/admission_review.rs
+++ b/src/admission_review.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 
 pub(crate) struct AdmissionReview {
-    pub request: String,
+    pub request: serde_json::Value,
     pub uid: String,
 }
 
@@ -17,14 +17,13 @@ impl AdmissionReview {
             None => return Err(anyhow!("Cannot parse AdmissionReview: 'request' not found")),
         };
 
-        let request = serde_json::to_string(req)?;
         let uid = match req.get("uid") {
             Some(uid) => uid.as_str().unwrap().to_string(),
             None => return Err(anyhow!("Cannot parse AdmissionReview: 'uid' not found")),
         };
 
         Ok(AdmissionReview {
-            request: request,
+            request: req.clone(),
             uid: uid,
         })
     }

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+
+use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
+use std::collections::HashMap;
+
+use std::fs::File;
+
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct Policy {
+  pub url: String,
+
+  #[serde(skip)]
+  pub wasm_module_path: String,
+
+  #[serde(flatten)]
+  extra_fields: HashMap<String, Value>,
+}
+
+impl Policy {
+  pub(crate) fn settings(&self) -> Mapping {
+    self
+      .extra_fields
+      .get("settings")
+      .map_or_else(Mapping::new, |s| s.as_mapping().unwrap().clone())
+  }
+}
+
+// Reads the policies configuration file, returns a HashMap with String as value
+// and Policy as values. The key is the name of the policy as provided by the user
+// inside of the configuration file. This name is used to build the API path
+// exposing the policy.
+pub(crate) fn read_policies_file(path: &str) -> Result<HashMap<String, Policy>> {
+  let settings_file = File::open(path)?;
+  let ps: HashMap<String, Policy> = serde_yaml::from_reader(&settings_file)?;
+  Ok(ps)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn get_settings_when_data_is_provided() -> std::result::Result<(), std::io::Error> {
+    let input = r#"
+---
+example:
+  url: file:///tmp/namespace-validate-policy.wasm
+  settings:
+    valid_namespace: valid
+"#;
+    let policies: HashMap<String, Policy> = serde_yaml::from_str(&input).unwrap();
+    assert_eq!(policies.is_empty(), false);
+
+    let policy = policies.get("example").unwrap();
+    let settings = policy.settings();
+    assert_ne!(settings.is_empty(), true);
+
+    Ok(())
+  }
+
+  #[test]
+  fn get_settings_when_empty_map_is_provided() -> std::result::Result<(), std::io::Error> {
+    let input = r#"
+---
+example:
+  url: file:///tmp/namespace-validate-policy.wasm
+  settings: {}
+"#;
+
+    let policies: HashMap<String, Policy> = serde_yaml::from_str(&input).unwrap();
+    assert_eq!(policies.is_empty(), false);
+
+    let policy = policies.get("example").unwrap();
+    let settings = policy.settings();
+    assert!(settings.is_empty());
+
+    Ok(())
+  }
+
+  #[test]
+  fn get_settings_when_no_settings_are_provided() -> std::result::Result<(), std::io::Error> {
+    let input = r#"
+---
+example:
+  url: file:///tmp/namespace-validate-policy.wasm
+"#;
+
+    let policies: HashMap<String, Policy> = serde_yaml::from_str(&input).unwrap();
+    assert_eq!(policies.is_empty(), false);
+
+    let policy = policies.get("example").unwrap();
+    let settings = policy.settings();
+    assert!(settings.is_empty());
+
+    Ok(())
+  }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,79 @@
+use anyhow::{anyhow, Result};
+
+// Helper function that takes a YAML map and returns a
+// JSON object.
+pub(crate) fn convert_yaml_map_to_json(
+    yml_map: serde_yaml::Mapping,
+) -> Result<serde_json::Map<String, serde_json::Value>> {
+    // convert the policy settings from yaml format to json
+    let yml_string = serde_yaml::to_string(&yml_map).map_err(|e| {
+        anyhow!(
+            "error while converting {:?} from yaml to string: {}",
+            yml_map,
+            e
+        )
+    })?;
+
+    let v: serde_json::Value = serde_yaml::from_str(&yml_string).map_err(|e| {
+        anyhow!(
+            "error while converting {:?} from yaml string to json: {}",
+            yml_map,
+            e
+        )
+    })?;
+
+    Ok(v.as_object()
+        .map_or_else(serde_json::Map::<String, serde_json::Value>::new, |m| {
+            m.clone()
+        }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policies::Policy;
+    use std::collections::HashMap;
+
+    #[test]
+    fn handle_yaml_map_with_data() -> std::result::Result<(), std::io::Error> {
+        let input = r#"
+---
+example:
+  url: file:///tmp/namespace-validate-policy.wasm
+  settings:
+    valid_namespace: valid
+"#;
+        let policies: HashMap<String, Policy> = serde_yaml::from_str(&input).unwrap();
+        assert_eq!(policies.is_empty(), false);
+
+        let policy = policies.get("example").unwrap();
+        let json_data = convert_yaml_map_to_json(policy.settings());
+        assert!(json_data.is_ok());
+
+        let settings = json_data.unwrap();
+        assert_eq!(settings.get("valid_namespace").unwrap(), "valid");
+
+        Ok(())
+    }
+
+    #[test]
+    fn handle_yaml_map_with_no_data() -> std::result::Result<(), std::io::Error> {
+        let input = r#"
+---
+example:
+  url: file:///tmp/namespace-validate-policy.wasm
+  settings: {}
+"#;
+        let policies: HashMap<String, Policy> = serde_yaml::from_str(&input).unwrap();
+        assert_eq!(policies.is_empty(), false);
+
+        let policy = policies.get("example").unwrap();
+        let json_data = convert_yaml_map_to_json(policy.settings());
+        assert!(json_data.is_ok());
+
+        let settings = json_data.unwrap();
+        assert!(settings.is_empty());
+
+        Ok(())
+    }
+}

--- a/src/wasm_fetcher/mod.rs
+++ b/src/wasm_fetcher/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use url::Url;
 use std::boxed::Box;
+use url::Url;
 
 pub mod fetcher;
 mod https;
@@ -34,4 +34,16 @@ pub(crate) fn parse_wasm_url(
     "registry" => Ok(Box::new(Registry::new(parsed_url, remote_non_tls)?)),
     _ => Err(anyhow!("unknown scheme: {}", parsed_url.scheme())),
   }
+}
+
+pub(crate) async fn fetch_wasm_module(url: String) -> Result<String> {
+  let fetcher = match parse_wasm_url(
+    &url, false, //TODO: remote insecure
+    false, //TODO: remote non tls
+  ) {
+    Ok(f) => f,
+    Err(e) => return Err(anyhow!("{}", e)),
+  };
+
+  fetcher.fetch().await
 }


### PR DESCRIPTION
This PR allows policy server to load multiple policies. Each policy has also its own settings, which tune how they behave.

The policies configuration file is a yml file like the following one:

```yaml
valid:
  url: file:///home/flavio/hacking/kubernetes/chimera/policy-server/namespace-validate-policy.wasm
  settings:
    valid_namespace: valid
flavio:
  url: file:///home/flavio/hacking/kubernetes/chimera/policy-server/namespace-validate-policy.wasm
  settings:
    valid_namespace: flavio
empty:
  url: file:///home/flavio/hacking/kubernetes/chimera/policy-server/namespace-validate-policy.wasm
  settings:
    foo: bar
nothing:
  url: file:///home/flavio/hacking/kubernetes/chimera/policy-server/namespace-validate-policy.wasm
```

Each policy is identified by a unique ID (`valid`, `flavio`, `empty`, `nothing` in the example above), this ID is used to build the endpoint of the policy. All the policies are exposed by the web API under the `/validate/<policyID>` endpoint.

Given the previous example, the policy server would reply to `POST` requests sent to:

  * `/validate/valid`
  * `/validate/flavio`
  * `/validate/empty`
  * `/validate/empty`

Finally, as you can see the same policy can be loaded several times, each time with a different set of settings.