### PR TITLE
Implement sources for Wasm modules origin

### DIFF
--- a/sources.yml.example
+++ b/sources.yml.example
@@ -1,0 +1,8 @@
+insecure_sources:
+  - "registry.dev.my-corp.com"
+  - "registry-2.dev.my-corp.com:5001"
+source_authorities:
+  "registry.pre.my-corp.com":
+    ca_path: "/path/to/ca.crt"
+  "registry-2.pre.my-corp.com:5001":
+    ca_path: "/path/to/ca.crt"

--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -12,12 +12,12 @@ pub(crate) struct DockerConfigRaw {
     auths: HashMap<String, RegistryAuthRaw>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum RegistryAuth {
     BasicAuth(Vec<u8>, Vec<u8>),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct DockerConfig {
     pub(crate) auths: HashMap<String, RegistryAuth>,
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+
+use native_tls::Certificate;
+
+use serde::Deserialize;
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::{fs, fs::File};
+
+#[derive(Default, Deserialize, Debug)]
+#[serde(default)]
+pub(crate) struct Sources {
+    insecure_sources: HashSet<String>,
+    source_authorities: HashMap<String, CertificateAuthority>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct CertificateAuthority {
+    ca_path: PathBuf,
+}
+
+impl Sources {
+    pub(crate) fn is_insecure_source<S: Into<String>>(&self, host: S) -> bool {
+        self.insecure_sources.contains(&host.into())
+    }
+
+    pub(crate) fn source_authority<S: Into<String>>(&self, host: S) -> Option<Certificate> {
+        self.source_authorities
+            .get(&host.into())
+            .and_then(|ca_path| fs::read_to_string(ca_path.ca_path.clone()).ok())
+            .and_then(|pem_certificate| {
+                // TODO (ereslibre): avoid parsing every time --
+                // initialize parsed certs, or warm-up cache
+                Certificate::from_pem(pem_certificate.as_bytes()).ok()
+            })
+    }
+}
+
+pub(crate) fn read_sources_file(path: &str) -> Result<Sources> {
+    Ok(serde_yaml::from_reader::<_, Sources>(File::open(path)?)?)
+}

--- a/src/wasm_fetcher/fetcher.rs
+++ b/src/wasm_fetcher/fetcher.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
+use crate::sources::Sources;
+
 // Generic interface for all the operations related with obtaining
 // a WASM module
 #[async_trait]
 pub(crate) trait Fetcher {
     // Download, if needed, the WASM module and return the path to the
     // file on the local disk
-    async fn fetch(&self) -> Result<String>;
+    async fn fetch(&self, sources: &Sources) -> Result<String>;
 }

--- a/src/wasm_fetcher/https.rs
+++ b/src/wasm_fetcher/https.rs
@@ -4,10 +4,11 @@ use async_std::prelude::*;
 use async_trait::async_trait;
 use hyper::{client::HttpConnector, Client, StatusCode};
 use hyper_tls::HttpsConnector;
-use native_tls::TlsConnector;
+use native_tls::{Certificate, TlsConnector};
 use std::{boxed::Box, path::Path};
 use url::Url;
 
+use crate::sources::Sources;
 use crate::wasm_fetcher::fetcher::Fetcher;
 
 // Struct used to reference a WASM module that is hosted on a HTTP(s) server
@@ -16,14 +17,18 @@ pub(crate) struct Https {
     destination: String,
     // url of the remote WASM module
     wasm_url: Url,
-    // do not verify the remote TLS certificate
-    insecure: bool,
+}
+
+enum TLSFetchMode {
+    CustomCA(Certificate),
+    SystemCA,
+    NoTLSVerification,
 }
 
 impl Https {
     // Allocates a LocalWASM instance starting from the user
     // provided URL
-    pub(crate) fn new(url: Url, remote_insecure: bool, download_dir: &str) -> Result<Https> {
+    pub(crate) fn new(url: Url, download_dir: &str) -> Result<Https> {
         let file_name = match url.path().rsplit('/').next() {
             Some(f) => f,
             None => {
@@ -42,18 +47,21 @@ impl Https {
                     .ok_or_else(|| anyhow!("Cannot build final path destination"))?,
             ),
             wasm_url: url,
-            insecure: remote_insecure,
         })
     }
-}
 
-#[async_trait]
-impl Fetcher for Https {
-    async fn fetch(&self) -> Result<String> {
+    async fn fetch_https(&self, fetch_mode: TLSFetchMode) -> Result<String> {
         let mut tls_connector_builder = TlsConnector::builder();
-        if self.insecure {
-            tls_connector_builder.danger_accept_invalid_certs(true);
-        }
+
+        match fetch_mode {
+            TLSFetchMode::CustomCA(certificate) => {
+                tls_connector_builder.add_root_certificate(certificate);
+            }
+            TLSFetchMode::SystemCA => (),
+            TLSFetchMode::NoTLSVerification => {
+                tls_connector_builder.danger_accept_invalid_certs(true);
+            }
+        };
 
         let mut http = HttpConnector::new();
         http.enforce_http(false);
@@ -61,7 +69,6 @@ impl Fetcher for Https {
         let https = HttpsConnector::from((http, tls.into()));
         let client = Client::builder().build::<_, hyper::Body>(https);
 
-        // not well: the hyper-tls connector handles both http and https scheme
         let res = client
             .get(self.wasm_url.clone().into_string().parse()?)
             .await?;
@@ -78,5 +85,67 @@ impl Fetcher for Https {
         file.write_all(&buf).await?;
 
         Ok(self.destination.clone())
+    }
+
+    async fn fetch_http(&self) -> Result<String> {
+        let http = HttpConnector::new();
+        let client = Client::builder().build::<_, hyper::Body>(http);
+
+        let res = client
+            .get(self.wasm_url.clone().into_string().parse()?)
+            .await?;
+        if res.status() != StatusCode::OK {
+            return Err(anyhow!(
+                "Error while downloading remote WASM module from {}, got HTTP status {}",
+                self.wasm_url,
+                res.status()
+            ));
+        }
+
+        let buf = hyper::body::to_bytes(res).await?;
+        let mut file = File::create(self.destination.clone()).await?;
+        file.write_all(&buf).await?;
+
+        Ok(self.destination.clone())
+    }
+}
+
+#[async_trait]
+impl Fetcher for Https {
+    async fn fetch(&self, sources: &Sources) -> Result<String> {
+        // 1. If CA's provided, download with provided CA's
+        // 2. If no CA's provided, download with system CA's
+        //   2.1. If it fails and if insecure is enabled for that host,
+        //     2.1.1. Download from HTTPs ignoring certificate errors
+        //     2.1.2. Download from HTTP
+
+        if self.wasm_url.scheme() == "https" {
+            let host = match self.wasm_url.host_str() {
+                Some(host) => Ok(host),
+                None => Err(anyhow!("cannot parse URI {}", self.wasm_url)),
+            }?;
+
+            if let Some(host_ca_certificate) = sources.source_authority(host) {
+                if let Ok(module_contents) = self
+                    .fetch_https(TLSFetchMode::CustomCA(host_ca_certificate))
+                    .await
+                {
+                    return Ok(module_contents);
+                } else if !sources.is_insecure_source(host) {
+                    return Err(anyhow!("could not download Wasm module from {} using provided CA certificate; aborting since host is not set as insecure", self.wasm_url));
+                }
+            }
+            if let Ok(module_contents) = self.fetch_https(TLSFetchMode::SystemCA).await {
+                return Ok(module_contents);
+            }
+            if !sources.is_insecure_source(host) {
+                return Err(anyhow!("could not download Wasm module from {} using system CA certificates; aborting since host is not set as insecure", self.wasm_url));
+            }
+            if let Ok(module_contents) = self.fetch_https(TLSFetchMode::NoTLSVerification).await {
+                return Ok(module_contents);
+            }
+        }
+
+        self.fetch_http().await
     }
 }

--- a/src/wasm_fetcher/local.rs
+++ b/src/wasm_fetcher/local.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
+use crate::sources::Sources;
 use crate::wasm_fetcher::fetcher::Fetcher;
 
 // Struct used to reference a WASM module that is already on the
@@ -22,7 +23,7 @@ impl Local {
 
 #[async_trait]
 impl Fetcher for Local {
-    async fn fetch(&self) -> Result<String> {
+    async fn fetch(&self, _sources: &Sources) -> Result<String> {
         Ok(self.local_path.clone())
     }
 }

--- a/src/wasm_fetcher/mod.rs
+++ b/src/wasm_fetcher/mod.rs
@@ -7,6 +7,10 @@ mod https;
 mod local;
 mod registry;
 
+use crate::registry::config::DockerConfig;
+
+use crate::sources::Sources;
+
 use crate::wasm_fetcher::fetcher::Fetcher;
 use crate::wasm_fetcher::https::Https;
 use crate::wasm_fetcher::local::Local;
@@ -16,9 +20,7 @@ use crate::wasm_fetcher::registry::Registry;
 // the right struct to interact with it
 pub(crate) fn parse_wasm_url(
     url: &str,
-    remote_insecure: bool,
-    remote_non_tls: bool,
-    docker_config_json_path: Option<String>,
+    docker_config: Option<DockerConfig>,
     download_dir: &str,
 ) -> Result<Box<dyn Fetcher>> {
     // we have to use url::Url instead of hyper::Uri because the latter one can't
@@ -32,15 +34,10 @@ pub(crate) fn parse_wasm_url(
 
     match parsed_url.scheme() {
         "file" => Ok(Box::new(Local::new(parsed_url.path()))),
-        "http" | "https" => Ok(Box::new(Https::new(
-            url.parse::<Url>()?,
-            remote_insecure,
-            download_dir,
-        )?)),
+        "http" | "https" => Ok(Box::new(Https::new(url.parse::<Url>()?, download_dir)?)),
         "registry" => Ok(Box::new(Registry::new(
             parsed_url,
-            remote_non_tls,
-            docker_config_json_path,
+            docker_config,
             download_dir,
         )?)),
         _ => Err(anyhow!("unknown scheme: {}", parsed_url.scheme())),
@@ -50,9 +47,10 @@ pub(crate) fn parse_wasm_url(
 pub(crate) async fn fetch_wasm_module(
     url: &str,
     download_dir: &str,
-    docker_config_json_path: Option<String>,
+    docker_config: Option<DockerConfig>,
+    sources: &Sources,
 ) -> Result<String> {
-    parse_wasm_url(&url, false, false, docker_config_json_path, download_dir)?
-        .fetch()
+    parse_wasm_url(&url, docker_config, download_dir)?
+        .fetch(sources)
         .await
 }


### PR DESCRIPTION
Implements https://github.com/chimera-kube/policy-server/issues/23

Now it is possible to provide a `sources.yaml` file that will inform
`policy-server` how to treat certain hosts, both for
HTTPs (`https://`) and oci-registry (`registry://`) origins.

The behavior of the implementation is very similar to Docker's
insecure registries.

The content of the sources.yaml file is of the form:

```yaml
insecure_sources: ["company-a.com", "company-b.com"]
source_authorities:
  company-c.com:
    ca_path: "/some/path/to/company-c-ca-chain.crt"
  company-d.com:
    ca_path: "/some/path/to/company-c-ca-chain.crt"
```

Behavior for `https://` scheme is as follows:

1. If CA's provided in source authorities, download with provided CA's
2. If no source authorities provided, download with system CA's
  2.1. If it fails and if unsafe is enabled for that host,
    2.1.1. Retry, download using HTTPs ignoring certificate errors
    2.1.2. Retry, download using HTTP

Behavior for `registry://` scheme is as follows:

1. Download with system CA's
  1.1. If it fails, and if unsafe is enabled for that host,
    1.1.1. Retry, download using HTTP

It is not possible to set specific CA's on source authorities for
`registry://` scheme yet, but it will be in the future, so both
schemes have the same behavior.