### PR TITLE
GitHub action: release static binary of policy-testdrive

### DIFF
--- a/.github/workflows/testdrive-release.yml
+++ b/.github/workflows/testdrive-release.yml
@@ -1,0 +1,43 @@
+name: policy-testdrive release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  BUILD_TARGET: x86_64-unknown-linux-musl
+  BINARY_NAME: chimera-policy-testdrive
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build-musl
+      uses: gmiam/rust-musl-action@master
+      with:
+        args: cargo build --target $BUILD_TARGET --release --bin ${{ env.BINARY_NAME }}
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release policy-testdrive ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: target/x86_64-unknown-linux-musl/release/${{ env.BINARY_NAME }}
+        asset_name: policy-testdrive-linux-amd64
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
Build the policy-testdrive binary in a staic way and add the final artifact to the release page